### PR TITLE
Update dotnet-core.yml

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Pack Nuget
       run: dotnet pack OpenWeatherMap.Standard/OpenWeatherMap.Standard.csproj --output ${{env.nuget_folder}} /p:Version=3.0.${{ github.run_attempt }} --configuration Release
     - name: publish Nuget Packages to GitHub
-      run: dotnet nuget push OpenWeatherMap.Standard\${{env.nuget_folder}}\\*.nupkg --source ${{vars.NUGET_FEED}} --api-key ${{secrets.NUGET_PACKAGE_UPLOAD}} --skip-duplicate
+      run: dotnet nuget push OpenWeatherMap.Standard\${{env.nuget_folder}}\\OpenWeatherMap.Standard.3.0.0.nupkg --source ${{vars.NUGET_FEED}} --api-key ${{secrets.NUGET_PACKAGE_UPLOAD}} --skip-duplicate
       if: github.event_name != 'pull_request'
     - name: Upload Artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request includes a small but important change to the GitHub Actions workflow for the .NET Core project. The change ensures that the correct NuGet package version is published.

## Workflow Improvements:

* [`.github/workflows/dotnet-core.yml`](diffhunk://#diff-36e3d7c516276ebd3d4a49df57499209ee1293dccca37fce615a1a69dcf716c0L33-R33): Modified the `dotnet nuget push` command to specify the exact NuGet package version (`OpenWeatherMap.Standard.3.0.0.nupkg`) to be published, ensuring that the correct package is uploaded.