### PR TITLE
update code coverage action

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -30,20 +30,21 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Test
-      run: dotnet test OpenWeatherMap.Standard.sln --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+      run: dotnet test OpenWeatherMap.Standard.sln --configuration Release-p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover --no-build --verbosity normal
 
-    - name: Code Coverage Report
-      uses: irongut/CodeCoverageSummary@v1.3.0
+    - name: Create Test Coverage Badge
+      uses: simon-k/dotnet-code-coverage-badge@v1.0.0
+      id: create_coverage_badge
       with:
-        filename: coverage/**/coverage.cobertura.xml
-        badge: true
-        fail_below_min: false
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: true
-        indicators: true
-        output: both
-        thresholds: '30 80'
+        label: Unit Test Coverage
+        color: brightgreen
+        path: OpenWeatherMap.Standard.Core.Test/TestResults/coverage.opencover.xml
+        gist-filename: code-coverage.json
+        gist-id: 05708cb0180d790434ef8a4b5499beb7
+        gist-auth-token: ${{ secrets.GIST_AUTH_TOKEN }}       
+    - name: Print code coverage
+      run: echo "Code coverage percentage ${{steps.create_coverage_badge.outputs.percentage}}%"
+
 
     - name: Pack Nuget
       run: dotnet pack OpenWeatherMap.Standard/OpenWeatherMap.Standard.csproj --output ${{env.nuget_folder}} /p:Version=3.0.${{ github.run_attempt }} --configuration Release

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -30,7 +30,7 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Test
-      run: dotnet test OpenWeatherMap.Standard.sln --configuration Release-p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover --no-build --verbosity normal
+      run: dotnet test OpenWeatherMap.Standard.sln --configuration Release -p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover --no-build --verbosity normal
 
     - name: Create Test Coverage Badge
       uses: simon-k/dotnet-code-coverage-badge@v1.0.0
@@ -44,7 +44,8 @@ jobs:
         gist-auth-token: ${{ secrets.GIST_AUTH_TOKEN }}       
     - name: Print code coverage
       run: echo "Code coverage percentage ${{steps.create_coverage_badge.outputs.percentage}}%"
-
+    - name: Print badge data
+      run: echo "Badge data ${{steps.create_coverage_badge.outputs.badge}}"
 
     - name: Pack Nuget
       run: dotnet pack OpenWeatherMap.Standard/OpenWeatherMap.Standard.csproj --output ${{env.nuget_folder}} /p:Version=3.0.${{ github.run_attempt }} --configuration Release

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CodeQL](https://github.com/vb2ae/OpenWeatherMap.Standard/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/vb2ae/OpenWeatherMap.Standard/actions/workflows/codeql-analysis.yml)
 
-![Code Coverage](https://img.shields.io/badge/Code%20Coverage-33%25-yellow?style=flat)
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/vb2ae/05708cb0180d790434ef8a4b5499beb7/raw/code-coverage.json)
 
 [![NuGet Package](https://img.shields.io/nuget/v/OpenWeatherMap.Standard.svg?logo=nuget&logoColor=white&&style=for-the-badge&colorB=green)](https://www.nuget.org/packages/OpenWeatherMap.Standard)
 


### PR DESCRIPTION
This pull request includes significant updates to the `.github/workflows/dotnet-core.yml` file, focusing on improving the test coverage reporting and badge creation process. The most important changes include updating the test command, replacing the code coverage report action, and adding a step to print the code coverage percentage.

Improvements to test coverage reporting:

* Updated the `dotnet test` command to include parameters for collecting coverage and specifying the output format as `opencover`.

Badge creation and reporting:

* Replaced the `irongut/CodeCoverageSummary` action with `simon-k/dotnet-code-coverage-badge` for creating a test coverage badge.
* Added a step to print the code coverage percentage using the output from the badge creation step.