### PR TITLE
fix path

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,7 +8,7 @@ on:
 env:
   package_feed: "https://nuget.pkg.github.com/vb2ae/index.json"
   nuget_folder: "\\packages"
-  nuget_upload: "\\packages\\*.nupkg"
+  nuget_upload: 'packages\*.nupkg'
 
 jobs:
   build:
@@ -59,7 +59,7 @@ jobs:
       run: echo "Badge data ${{steps.create_coverage_badge.outputs.badge}}"
 
     - name: Pack Nuget
-      run: dotnet pack OpenWeatherMap.Standard/OpenWeatherMap.Standard.csproj --output ${{env.nuget_folder}} /p:Version=3.0.${{ github.run_attempt }} --configuration Release
+      run: dotnet pack OpenWeatherMap.Standard/OpenWeatherMap.Standard.csproj --output ${{env.nuget_folder}} --configuration Release
     - name: publish Nuget Packages to GitHub
       run: dotnet nuget push ${{env.nuget_upload}} --source ${{vars.NUGET_FEED}} --api-key ${{secrets.NUGET_PACKAGE_UPLOAD}} --skip-duplicate
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/dotnet-core.yml` file to improve the NuGet package handling and streamline the build process. The most important changes include fixing the path format for `nuget_upload` and removing the version parameter from the `dotnet pack` command.

Improvements to NuGet package handling:

* [`.github/workflows/dotnet-core.yml`](diffhunk://#diff-36e3d7c516276ebd3d4a49df57499209ee1293dccca37fce615a1a69dcf716c0L11-R11): Fixed the path format for `nuget_upload` by changing from double backslashes to single backslashes.

Streamlining the build process:

* [`.github/workflows/dotnet-core.yml`](diffhunk://#diff-36e3d7c516276ebd3d4a49df57499209ee1293dccca37fce615a1a69dcf716c0L62-R62): Removed the version parameter from the `dotnet pack` command to simplify the packaging process.