### PR TITLE
Update NuGet upload path in dotnet-core.yml

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,7 +8,7 @@ on:
 env:
   package_feed: "https://nuget.pkg.github.com/ken-tucker/index.json"
   nuget_folder: "\\packages"
-  nuget_upload: 'packages\*.nupkg'
+  nuget_upload: 'OpenWeatherMap.Standard/packages/*.nupkg'
 
 jobs:
   build:


### PR DESCRIPTION
The `nuget_upload` path has been updated from 'packages\*.nupkg' to 'OpenWeatherMap.Standard/packages/*.nupkg' in the `dotnet-core.yml` file. This change specifies a more precise directory for the NuGet package upload location.