### PR TITLE
fix

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,7 +8,7 @@ on:
 env:
   package_feed: "https://nuget.pkg.github.com/ken-tucker/index.json"
   nuget_folder: "\\packages"
-  nuget_upload: 'OpenWeatherMap.Standard/packages/*.nupkg'
+  nuget_upload: 'packages/*.nupkg'
 
 jobs:
   build:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/dotnet-core.yml` file. The change updates the `nuget_upload` path to a more general directory. 

* [`.github/workflows/dotnet-core.yml`](diffhunk://#diff-36e3d7c516276ebd3d4a49df57499209ee1293dccca37fce615a1a69dcf716c0L11-R11): Changed the `nuget_upload` path from `'OpenWeatherMap.Standard/packages/*.nupkg'` to `'packages/*.nupkg'` to generalize the upload directory.