### PR TITLE
Update package versions across multiple projects

### DIFF
--- a/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
+++ b/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
@@ -16,11 +16,11 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.2.5" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.5" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.5" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.5" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.4" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.5" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />

--- a/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
+++ b/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
@@ -30,4 +30,9 @@
   <ItemGroup>
     <ProjectReference Include="..\OpenWeatherMap.Standard\OpenWeatherMap.Standard.csproj" />
   </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.115" />
+  </ItemGroup>
 </Project>

--- a/OpenWeatherMap.Standard.Core.Test/OpenWeatherMap.Standard.Core.Test.csproj
+++ b/OpenWeatherMap.Standard.Core.Test/OpenWeatherMap.Standard.Core.Test.csproj
@@ -36,4 +36,8 @@
     <Folder Include="TestResults\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.115" />
+  </ItemGroup>
+
 </Project>

--- a/OpenWeatherMap.Standard.MVC.Sample/OpenWeatherMap.Standard.MVC.Sample.csproj
+++ b/OpenWeatherMap.Standard.MVC.Sample/OpenWeatherMap.Standard.MVC.Sample.csproj
@@ -13,4 +13,8 @@
       <ProjectReference Include="..\OpenWeatherMap.Standard\OpenWeatherMap.Standard.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.115" />
+    </ItemGroup>
+
 </Project>

--- a/OpenWeatherMap.Standard.Sample/OpenWeatherMap.Standard.Sample.csproj
+++ b/OpenWeatherMap.Standard.Sample/OpenWeatherMap.Standard.Sample.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\OpenWeatherMap.Standard\OpenWeatherMap.Standard.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.115" />
+  </ItemGroup>
+
 </Project>

--- a/OpenWeatherMap.Standard/OpenWeatherMap.Standard.csproj
+++ b/OpenWeatherMap.Standard/OpenWeatherMap.Standard.csproj
@@ -55,4 +55,8 @@
 	    <PackagePath>\</PackagePath>
 	  </None>
 	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.115" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION

This pull request includes updates to package references across multiple project files to ensure consistency and to introduce the `Nerdbank.GitVersioning` package.

Package updates:

* Updated `Avalonia.Desktop`, `Avalonia.Themes.Fluent`, `Avalonia.Fonts.Inter`, and `Avalonia.Diagnostics` package versions to `11.2.5` in `OpenWeatherMap.Avalonia.Sample.csproj`.

Addition of `Nerdbank.GitVersioning` package:

* Added `Nerdbank.GitVersioning` package reference with version `3.7.115` to `OpenWeatherMap.Avalonia.Sample.csproj`.
* Added `Nerdbank.GitVersioning` package reference with version `3.7.115` to `OpenWeatherMap.Standard.Core.Test.csproj`.
* Added `Nerdbank.GitVersioning` package reference with version `3.7.115` to `OpenWeatherMap.Standard.MVC.Sample.csproj`.
* Added `Nerdbank.GitVersioning` package reference with version `3.7.115` to `OpenWeatherMap.Standard.Sample.csproj`.
* Added `Nerdbank.GitVersioning` package reference with version `3.7.115` to `OpenWeatherMap.Standard.csproj`.

closing #114 