### PR TITLE
update to avalonia 12

### DIFF
--- a/OpenWeatherMap.Avalonia.Sample/App.axaml.cs
+++ b/OpenWeatherMap.Avalonia.Sample/App.axaml.cs
@@ -26,11 +26,6 @@ namespace OpenWeatherMap.Avalonia.Sample
                 // Creates a ServiceProvider containing services from the provided IServiceCollection
                 var services = collection.BuildServiceProvider();
 
-
-                // Line below is needed to remove Avalonia data validation.
-                // Without this line you will get duplicate validations from both Avalonia and CT
-                BindingPlugins.DataValidators.RemoveAt(0);
-
                 var vm = services.GetRequiredService<MainWindowViewModel>();
                 desktop.MainWindow = new MainWindow
                 {

--- a/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
+++ b/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
@@ -15,12 +15,12 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.13" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.13" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.14" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />


### PR DESCRIPTION
This pull request updates the Avalonia dependencies to version 12.0.1 and removes a workaround related to Avalonia data validation that is no longer needed with the new version. These changes help keep the project up to date and simplify the initialization code.

Dependency upgrades:

* Updated `Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`, and `Avalonia.Fonts.Inter` package references from version 11.3.13 to 12.0.1 in `OpenWeatherMap.Avalonia.Sample.csproj`. Also updated `Avalonia.Diagnostics` (Debug only) to 11.3.14.

Code cleanup:

* Removed the line disabling Avalonia's built-in data validation (`BindingPlugins.DataValidators.RemoveAt(0)`) from `App.axaml.cs`, as this workaround is no longer necessary with Avalonia 12.