### PR TITLE
Update Avalonia packages to version 12.0.2

### DIFF
--- a/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
+++ b/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
@@ -15,10 +15,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <PackageReference Include="Avalonia" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.2" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.14" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />


### PR DESCRIPTION
Upgraded Avalonia, Avalonia.Desktop, Avalonia.Themes.Fluent, and Avalonia.Fonts.Inter NuGet packages from 12.0.1 to 12.0.2 in the project file. No other changes were made.