### PR TITLE
Update Avalonia and test SDK package versions

### DIFF
--- a/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
+++ b/OpenWeatherMap.Avalonia.Sample/OpenWeatherMap.Avalonia.Sample.csproj
@@ -17,8 +17,8 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="12.0.4" />
     <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.17" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />

--- a/OpenWeatherMap.Standard.Core.Test/OpenWeatherMap.Standard.Core.Test.csproj
+++ b/OpenWeatherMap.Standard.Core.Test/OpenWeatherMap.Standard.Core.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Upgraded Avalonia.Themes.Fluent and Avalonia.Fonts.Inter to 12.0.4 in the sample project. Updated Microsoft.NET.Test.Sdk to 18.6.0 in the test project. Added a UTF-8 BOM to the test project file.